### PR TITLE
fix: simplify max depth for users

### DIFF
--- a/pkg/project/config.go
+++ b/pkg/project/config.go
@@ -58,7 +58,7 @@ func NewConfig(cfg cmdutil.Config) (Config, error) {
 }
 
 func (c Config) setDefaults() Config {
-	c.MaxDepth = cmp.Or(c.MaxDepth, 4)
+	c.MaxDepth = cmp.Or(c.MaxDepth, 3)
 
 	if c.Root == "" {
 		c.Root = "~/Projects"

--- a/pkg/project/list_local.go
+++ b/pkg/project/list_local.go
@@ -19,9 +19,11 @@ func (s *Service) listLocalProjects(ctx context.Context, opts *ListOptions) ([]P
 
 func (s *Service) loadLocalProjects(ctx context.Context) ([]Project, error) {
 	var (
-		glob        = true
-		hidden      = true
-		maxDepth    = s.cfg.MaxDepth
+		glob   = true
+		hidden = true
+		// maxDepth should be increased by 1, so that it finds the `.git`
+		// directory inside a project directory.
+		maxDepth    = s.cfg.MaxDepth + 1
 		noIgnoreVCS = true
 		follow      = true
 		root        = s.cfg.Root


### PR DESCRIPTION
Simplify max depth configuration for users, to hide the fact we're looking for
the `.git` directory in each project, to determine if it's a valid "project".
