### PR TITLE
fix: retrieve all remote repos at once

### DIFF
--- a/pkg/gh/repo.go
+++ b/pkg/gh/repo.go
@@ -33,6 +33,7 @@ func (c *Client) ListRepos(ctx context.Context, opts *RepoListOptions) ([]*Repo,
 	cmd := c.executor.CommandContext(
 		ctx,
 		"gh", "repo", "list",
+		"--limit", "9999",
 		opts.Owner, "--json", "owner,name",
 	)
 


### PR DESCRIPTION
## Description

Retrieve all remote repositories at once by leveraging `--limit 9999`.
